### PR TITLE
Tipo de variable semilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ var_dump($sorteados);
 array(10) { [0]=> int(2) [1]=> int(6) [2]=> int(3) [3]=> int(7) [4]=> int(4) [5]=> int(9) [6]=> int(8) [7]=> int(5) [8]=> int(10) [9]=> int(1) } 
 ```
 
-El hash se podría formar de la siguiente manera:
+El hash de validación del sorteo se podría formar de la siguiente manera:
 ```php
-sha1($bolillero->getMomento().';'.$bolillero->getSemilla().';'.implode(',', $bolillero->getNumerosSorteados()));
+$momento = $sorteo->getMomento()->getTimestamp(); // El timestamp del mometo que finaliza y se guarda el sorteo
+sha1($momento.';'.$bolillero->getSemilla().';'.implode(',', $bolillero->getNumerosSorteados()));
 ```
 
 # Tests

--- a/src/Cespi/SipecuBundle/Util/Bolillero.php
+++ b/src/Cespi/SipecuBundle/Util/Bolillero.php
@@ -51,11 +51,8 @@ class Bolillero
     
     private function generarSemilla()
     {
-        list($microsegundos, $segundos) = explode(' ', microtime()); //Flotante: "segundos microsegundos" (6 decimales de precisión)
-        $segundos = (int) ($segundos * 1000000); // 6 decimales de microsegundos
-        $microsegundos = (int) ($microsegundos * 1000000);
-        $this->semilla = $segundos + $microsegundos; // microsegundos hasta la fecha (entero)
-        mt_srand($this->semilla); //El valor del parámetro entero está en 32 bits, por lo que tomará los últimos 32 bits del valor (en 64bits)
+        $this->semilla = microtime(true); // microsegundos hasta la fecha (float: "segundos.microsegundos", para arquitecturas de 32 y 64 bits, ya que el tamaño del entero en microsegundos con 6 decimales de precisión no entra en 32bits, y el valor variaría dependiendo de la arquitectura)
+        mt_srand($this->semilla); //El valor del parámetro entero está en 32 bits, por lo que tomará los últimos 32 bits del valor (de float)
     }
     
     public function getSemilla()
@@ -80,7 +77,7 @@ class Bolillero
         {
             $j = mt_rand($i, $hasta);
             self::intercambiar($this->numerosSorteados[$i], $this->numerosSorteados[$j]); //intercambio de valores
-        }
+            }
         $this->finSorteo();
 
         return $this->getNumerosSorteados();


### PR DESCRIPTION
Hola, cambié el tipo de variable de la semilla. La semilla continúa siendo la misma, pero en lugar se ser un entero con microsegundos de 6 dígitos, es un flotante con microsegundos de 4 (decimales). Esto es para evitar las diferencias en el tamaño de los enteros en arquitecturas de 64 y 32 bits. 
