### PR TITLE
Posible vulnerabilidad encontrada en generación de números random en PHP

### DIFF
--- a/src/Cespi/SipecuBundle/Util/Bolillero.php
+++ b/src/Cespi/SipecuBundle/Util/Bolillero.php
@@ -5,14 +5,14 @@ namespace Cespi\SipecuBundle\Util;
 /*
  * Sipecu Bolillero - Módulo que implementa el sorteo para la asignación de vacantes a los colegios de la UNLP.
  * Copyright (C) 2015 CeSPI - UNLP <sistemasacademicos@unlp.edu.ar>
- * 
+ *
  * Este archivo es parte de SIPECU.
  *
- * Bolillero.php es software libre:  puede redistribuirlo y/o modificarlo 
+ * Bolillero.php es software libre:  puede redistribuirlo y/o modificarlo
  * bajo los términos de la GNU General Public License v2.0 <http://www.gnu.org/licenses/gpl-2.0.html>.
  *
  * Versión: 1.0
- * 
+ *
  */
 
 /**
@@ -56,7 +56,7 @@ class Bolillero
         }
         $this->numeros = range(1, $mayorNumero);
     }
-    
+
     private function generarSemilla()
     {
         list($microsegundos, $segundos) = explode(' ', microtime()); //Flotante: "segundos microsegundos" (6 decimales de precisión)
@@ -65,8 +65,14 @@ class Bolillero
         $microsegundos = (int) ($microsegundos * 1000000);
         $this->semilla = $segundos + $microsegundos; // microsegundos hasta la fecha (entero)
         mt_srand($this->semilla); //El valor del parámetro entero está en 32 bits, por lo que tomará los últimos 32 bits del valor (en 64bits)
+
+        ## Ojo acá que no se genera la entropía suficiente como para tener un valor random seguro.
+        ## Se aconseja utilizar alguna librería para la generación de número random con buena entropía para PHP
+        ## Artículo que habla de las posibles vulnerabilidades sobre ésto: https://github.com/padraic/phpsecurity/blob/master/book/lang/en/source/Insufficient-Entropy-For-Random-Values.rst
+        ## Librería para generar mejor entropía en número random para PHP: https://github.com/ircmaxell/RandomLib
+        
     }
-    
+
     public function getSemilla()
     {
         return $this->semilla;
@@ -76,7 +82,7 @@ class Bolillero
     {
         return $this->strMicrotime;
     }
-   
+
     public function sortear()
     {
         if ($this->getSorteado())
@@ -104,7 +110,7 @@ class Bolillero
         $x=$y;
         $y=$tmp;
     }
-    
+
     public function getNumerosSorteados()
     {
 
@@ -116,23 +122,23 @@ class Bolillero
 
         return $this->sorteado;
     }
-    
+
     private function inicioSorteo()
     {
         $this->generarSemilla();
         $this->numerosSorteados = array_values($this->numeros);
     }
-    
+
     private function finSorteo()
     {
         $this->marcarSorteado();
     }
-    
+
     private function marcarSorteado()
     {
         $this->sorteado = true;
     }
-    
+
     public function __toString()
     {
         return implode(' ', $this->getNumerosSorteados());


### PR DESCRIPTION
El sistema Sipecu del Cespi contiene el módulo bolillero el cual implementa el sorteo para la asignación de vacantes a colegios. Para la asignación de los números del sorteo utiliza una función de random de PHP la cual no es segura según el siguiente artículo:
https://github.com/padraic/phpsecurity/blob/master/book/lang/en/source/Insufficient-Entropy-For-Random-Values.rst

En el artículo básicamente se detalla que las funciones primitivas para la generación de números aleatorios en PHP pueden ser sencillamente replicadas, reconstruidas o vulneradas debido a la poca entropía en la generación de dichos números. Ésto, prosigue el artículo, puede significar en adivinación o obtención de salts, claves débiles o cualquier tipo de meta información para recuperar datos privados o que no deberían ser duplicados u obtenidos de ésta forma. Luego de un exhaustivo análisis de los distintos ataques posibles por ésta falta de entropía y cómo llevarlos a cabo el autor del artículo explica una posible solución. La solución planteada es la utilización de la librería RandomLib library on Github creada por Anthony Ferrara (https://github.com/ircmaxell/RandomLib) la cual se consigue generar la suficiente entropía para que al menos sea mucho más difícil y cueste mucho más trabajo obtener los números generados.